### PR TITLE
Replace undefined Function `fallback_locale` by default configuration

### DIFF
--- a/src/Behaviours/HasTranslation.php
+++ b/src/Behaviours/HasTranslation.php
@@ -36,7 +36,7 @@ trait HasTranslation
      * @param $text
      * @return array|mixed|string|null
      */
-    function getTranslated($input)
+    public function getTranslated($input)
     {
         if (is_string($input)) {
             return ___($input, locale());
@@ -44,7 +44,7 @@ trait HasTranslation
 
         if (is_traversable($input)) {
             return $input[$this->getActiveLocale() ?? locale()] ??
-                ($input[fallback_locale()] ?? '');
+                ($input[config('translatable.fallback_locale')] ?? '');
         }
 
         return null;

--- a/src/RepositoryTrait.php
+++ b/src/RepositoryTrait.php
@@ -56,7 +56,7 @@ trait RepositoryTrait
         $objects[] = $this;
 
         return collect($objects)->reduce(
-            fn($name, $object) => $name ??
+            fn ($name, $object) => $name ??
                 $this->getTemplateNameFromObject($object),
         );
     }
@@ -80,7 +80,7 @@ trait RepositoryTrait
                 ->pluck('locale')
                 ->contains($locale = locale())
                 ? $locale
-                : fallback_locale();
+                : config('translatable.fallback_locale');
         }
 
         return locale();


### PR DESCRIPTION
When using the transformers and dealing with translations. It raises an error due to the `fallback_locale` function is not defined.

## Description

Removed the usage of the `fallback_locale` function and replace by the usage of the default configuration:

```php
config('translatable.fallback_locale')
```

## Motivation and context

The need of using translation and handling properly the fallbacks.

## How has this been tested?

I've update the configuration to point to the my fork.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
