### PR TITLE
Add support of block class to get the media params

### DIFF
--- a/src/Behaviours/HasMedia.php
+++ b/src/Behaviours/HasMedia.php
@@ -314,6 +314,10 @@ trait HasMedia
                 ? $this->getMediasParams()
                 : null;
 
+        $mediasParams ??= ! blank($object) && $object->data instanceof \A17\Twill\Models\Block
+            ? $object->getMediasParams()
+            : null;
+
         $mediasParams ??= method_exists($object, 'getMediasParams')
             ? $object->getMediasParams()
             : $this->extractMediasParamsFromModel($object);


### PR DESCRIPTION
## Description

I was in version 1.1.7, everything worked well with my blocks. I needed to update the package to get the related browser and another problem came to me. My pictures had disappeared from my blocks after the update.

## Motivation and context

I need to get the media parameters from a current block.

## How has this been tested?

For now, I only tested it inside my current project. The context: I want to dump the `$object->getMediasParams();` and the `$this->extractMediasParamsFromModel($object);`. There is the result:
<img width="838" alt="image" src="https://user-images.githubusercontent.com/48125516/233018772-34bc8c30-c11d-4dbf-98c6-6811bda006f6.png">

So, I made the code to catch the `$object->getMediasParams();` within the block class is detected.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
